### PR TITLE
New `enableSafeArea` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.0 - 21.06.2022
+* **Breaking change**. Padding parameters replaced with a single EdgeInsets `padding` parameter.
+* **Breaking change**. `showOutAnimationDuration` renamed to `animationDuration`, `hideOutAnimationDuration` renamed to `reverseAnimationDuration`.
+* Enhancement [#24](https://github.com/vizhan-lanars/top-snackbar-flutter/issues/24). Add `curve` and `reverseCurve` parameters.
+
 ## 1.1.1 - 18.05.2022
 * Fix persistent snackbar behaviour
 

--- a/lib/top_snack_bar.dart
+++ b/lib/top_snack_bar.dart
@@ -44,12 +44,7 @@ void showTopSnackBar(
   OverlayState? overlayState,
   bool persistent = false,
   ControllerCallback? onAnimationControllerInit,
-  EdgeInsets padding = const EdgeInsets.only(
-    left: 16,
-    right: 16,
-    bottom: 0,
-    top: 16,
-  ),
+  EdgeInsets padding = const EdgeInsets.all(16),
   Curve curve = Curves.elasticOut,
   Curve reverseCurve = Curves.linearToEaseOut,
 }) async {

--- a/lib/top_snack_bar.dart
+++ b/lib/top_snack_bar.dart
@@ -34,6 +34,9 @@ OverlayEntry? _previousEntry;
 ///
 /// [curve] and [reverseCurve] arguments are used to specify curves
 /// for in and out animations respectively
+///
+/// The [enableSafeArea] argument is used to specify the `top` argument of the
+/// [SafeArea] widget that wrap the snackbar. Defaults to `true`.
 void showTopSnackBar(
   BuildContext context,
   Widget child, {
@@ -47,6 +50,7 @@ void showTopSnackBar(
   EdgeInsets padding = const EdgeInsets.all(16),
   Curve curve = Curves.elasticOut,
   Curve reverseCurve = Curves.linearToEaseOut,
+  bool enableSafeArea = true,
 }) async {
   overlayState ??= Overlay.of(context);
   late OverlayEntry overlayEntry;
@@ -69,6 +73,7 @@ void showTopSnackBar(
         padding: padding,
         curve: curve,
         reverseCurve: reverseCurve,
+        enableSafeArea: enableSafeArea,
       );
     },
   );
@@ -93,6 +98,7 @@ class TopSnackBar extends StatefulWidget {
   final EdgeInsets padding;
   final Curve curve;
   final Curve reverseCurve;
+  final bool enableSafeArea;
 
   TopSnackBar({
     Key? key,
@@ -107,6 +113,7 @@ class TopSnackBar extends StatefulWidget {
     required this.padding,
     required this.curve,
     required this.reverseCurve,
+    this.enableSafeArea = true,
   }) : super(key: key);
 
   @override
@@ -185,6 +192,7 @@ class _TopSnackBarState extends State<TopSnackBar>
       child: SlideTransition(
         position: offsetAnimation as Animation<Offset>,
         child: SafeArea(
+          top: widget.enableSafeArea,
           child: TapBounceContainer(
             onTap: () {
               if (mounted) {

--- a/lib/top_snack_bar.dart
+++ b/lib/top_snack_bar.dart
@@ -31,6 +31,9 @@ OverlayEntry? _previousEntry;
 /// [AnimationController] has been initialized.
 ///
 /// The [padding] argument is used to specify amount of outer padding
+///
+/// [curve] and [reverseCurve] arguments are used to specify curves
+/// for in and out animations respectively
 void showTopSnackBar(
   BuildContext context,
   Widget child, {
@@ -47,6 +50,8 @@ void showTopSnackBar(
     bottom: 0,
     top: 16,
   ),
+  Curve curve = Curves.elasticOut,
+  Curve reverseCurve = Curves.linearToEaseOut,
 }) async {
   overlayState ??= Overlay.of(context);
   late OverlayEntry overlayEntry;
@@ -67,6 +72,8 @@ void showTopSnackBar(
         persistent: persistent,
         onAnimationControllerInit: onAnimationControllerInit,
         padding: padding,
+        curve: curve,
+        reverseCurve: reverseCurve,
       );
     },
   );
@@ -89,6 +96,8 @@ class TopSnackBar extends StatefulWidget {
   final ControllerCallback? onAnimationControllerInit;
   final bool persistent;
   final EdgeInsets padding;
+  final Curve curve;
+  final Curve reverseCurve;
 
   TopSnackBar({
     Key? key,
@@ -101,6 +110,8 @@ class TopSnackBar extends StatefulWidget {
     this.persistent = false,
     this.onAnimationControllerInit,
     required this.padding,
+    required this.curve,
+    required this.reverseCurve,
   }) : super(key: key);
 
   @override
@@ -111,11 +122,9 @@ class _TopSnackBarState extends State<TopSnackBar>
     with SingleTickerProviderStateMixin {
   late Animation offsetAnimation;
   late AnimationController animationController;
-  double? topPosition;
 
   @override
   void initState() {
-    topPosition = widget.padding.top;
     _setupAndStartAnimation();
     super.initState();
   }
@@ -143,8 +152,8 @@ class _TopSnackBarState extends State<TopSnackBar>
     offsetAnimation = offsetTween.animate(
       CurvedAnimation(
         parent: animationController,
-        curve: Curves.elasticOut,
-        reverseCurve: Curves.linearToEaseOut,
+        curve: widget.curve,
+        reverseCurve: widget.reverseCurve,
       ),
     )..addStatusListener((status) async {
         if (status == AnimationStatus.completed) {
@@ -169,18 +178,13 @@ class _TopSnackBarState extends State<TopSnackBar>
   void _dismiss() {
     if (mounted) {
       animationController.reverse();
-      setState(() {
-        topPosition = 0;
-      });
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedPositioned(
-      duration: widget.reverseAnimationDuration * 1.5,
-      curve: Curves.linearToEaseOut,
-      top: topPosition,
+    return Positioned(
+      top: widget.padding.top,
       left: widget.padding.left,
       right: widget.padding.right,
       child: SlideTransition(

--- a/lib/top_snack_bar.dart
+++ b/lib/top_snack_bar.dart
@@ -10,16 +10,13 @@ OverlayEntry? _previousEntry;
 ///
 /// The [child] argument is used to pass widget that you want to show
 ///
-/// The [showOutAnimationDuration] argument is used to specify duration of
+/// The [animationDuration] argument is used to specify duration of
 /// enter transition
 ///
-/// The [hideOutAnimationDuration] argument is used to specify duration of
+/// The [reverseAnimationDuration] argument is used to specify duration of
 /// exit transition
 ///
 /// The [displayDuration] argument is used to specify duration displaying
-///
-/// The [additionalTopPadding] argument is used to specify amount of top
-/// padding that will be added for SafeArea values
 ///
 /// The [onTap] callback of [TopSnackBar]
 ///
@@ -32,19 +29,24 @@ OverlayEntry? _previousEntry;
 ///
 /// The [onAnimationControllerInit] callback is called on internal
 /// [AnimationController] has been initialized.
+///
+/// The [padding] argument is used to specify amount of outer padding
 void showTopSnackBar(
   BuildContext context,
   Widget child, {
-  Duration showOutAnimationDuration = const Duration(milliseconds: 1200),
-  Duration hideOutAnimationDuration = const Duration(milliseconds: 550),
+  Duration animationDuration = const Duration(milliseconds: 1200),
+  Duration reverseAnimationDuration = const Duration(milliseconds: 550),
   Duration displayDuration = const Duration(milliseconds: 3000),
-  double additionalTopPadding = 16.0,
   VoidCallback? onTap,
   OverlayState? overlayState,
-  double leftPadding = 16,
-  double rightPadding = 16,
   bool persistent = false,
   ControllerCallback? onAnimationControllerInit,
+  EdgeInsets padding = const EdgeInsets.only(
+    left: 16,
+    right: 16,
+    bottom: 0,
+    top: 16,
+  ),
 }) async {
   overlayState ??= Overlay.of(context);
   late OverlayEntry overlayEntry;
@@ -58,15 +60,13 @@ void showTopSnackBar(
             _previousEntry = null;
           }
         },
-        showOutAnimationDuration: showOutAnimationDuration,
-        hideOutAnimationDuration: hideOutAnimationDuration,
+        animationDuration: animationDuration,
+        reverseAnimationDuration: reverseAnimationDuration,
         displayDuration: displayDuration,
-        additionalTopPadding: additionalTopPadding,
         onTap: onTap,
-        leftPadding: leftPadding,
-        rightPadding: rightPadding,
         persistent: persistent,
         onAnimationControllerInit: onAnimationControllerInit,
+        padding: padding,
       );
     },
   );
@@ -82,29 +82,25 @@ void showTopSnackBar(
 class TopSnackBar extends StatefulWidget {
   final Widget child;
   final VoidCallback onDismissed;
-  final showOutAnimationDuration;
-  final hideOutAnimationDuration;
-  final displayDuration;
-  final additionalTopPadding;
+  final Duration animationDuration;
+  final Duration reverseAnimationDuration;
+  final Duration displayDuration;
   final VoidCallback? onTap;
   final ControllerCallback? onAnimationControllerInit;
-  final double leftPadding;
-  final double rightPadding;
   final bool persistent;
+  final EdgeInsets padding;
 
   TopSnackBar({
     Key? key,
     required this.child,
     required this.onDismissed,
-    required this.showOutAnimationDuration,
-    required this.hideOutAnimationDuration,
+    required this.animationDuration,
+    required this.reverseAnimationDuration,
     required this.displayDuration,
-    required this.additionalTopPadding,
     this.onTap,
-    this.leftPadding = 16,
-    this.rightPadding = 16,
     this.persistent = false,
     this.onAnimationControllerInit,
+    required this.padding,
   }) : super(key: key);
 
   @override
@@ -119,7 +115,7 @@ class _TopSnackBarState extends State<TopSnackBar>
 
   @override
   void initState() {
-    topPosition = widget.additionalTopPadding;
+    topPosition = widget.padding.top;
     _setupAndStartAnimation();
     super.initState();
   }
@@ -133,8 +129,8 @@ class _TopSnackBarState extends State<TopSnackBar>
   void _setupAndStartAnimation() async {
     animationController = AnimationController(
       vsync: this,
-      duration: widget.showOutAnimationDuration,
-      reverseDuration: widget.hideOutAnimationDuration,
+      duration: widget.animationDuration,
+      reverseDuration: widget.reverseAnimationDuration,
     );
 
     widget.onAnimationControllerInit?.call(animationController);
@@ -182,11 +178,11 @@ class _TopSnackBarState extends State<TopSnackBar>
   @override
   Widget build(BuildContext context) {
     return AnimatedPositioned(
-      duration: widget.hideOutAnimationDuration * 1.5,
+      duration: widget.reverseAnimationDuration * 1.5,
       curve: Curves.linearToEaseOut,
       top: topPosition,
-      left: widget.leftPadding,
-      right: widget.rightPadding,
+      left: widget.padding.left,
+      right: widget.padding.right,
       child: SlideTransition(
         position: offsetAnimation as Animation<Offset>,
         child: SafeArea(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: top_snackbar_flutter
 description: Top snack bar package was created for nice and convenient way to inform users about what happened.
-version: 1.1.1
+version: 2.0.0
 homepage: https://github.com/LanarsInc/top-snackbar-flutter
 
 environment:


### PR DESCRIPTION
Allow to disable the top SafeArea parameter that wrap the snackbar child