### PR TITLE
New swipe to dismiss action

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -87,6 +87,21 @@ class _MyAppState extends State<MyApp> {
                     onTap: () => localAnimationController.reverse(),
                     child: buildButton(context, "Dismiss persistent SnackBar"),
                   ),
+                  SizedBox(height: 24),
+                  TapBounceContainer(
+                    onTap: () {
+                      showTopSnackBar(
+                        context,
+                        CustomSnackBar.info(message: "Try to swipe me left"),
+                        dismissType: TopSnackBarDismissType.onSwipe,
+                        dismissDirection: DismissDirection.endToStart,
+                      );
+                    },
+                    child: buildButton(
+                      context,
+                      "Show swiped dismissable SnackBar",
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/lib/top_snack_bar.dart
+++ b/lib/top_snack_bar.dart
@@ -224,7 +224,7 @@ class _TopSnackBarState extends State<TopSnackBar>
       case TopSnackBarDismissType.onSwipe:
         return Dismissible(
           direction: widget.dismissDirection,
-          key: Key('top_snack_bar_${widget.child.hashCode}'),
+          key: UniqueKey(),
           onDismissed: (direction) {
             if (!widget.persistent) {
               _dismiss();


### PR DESCRIPTION
New `dismissType` and `dismissDirection` parameters

This PR Allow to dismiss the snackbar throughout swipe action. (similar to push notification).

User can still choose the dismiss behavior (TopSnackBarDismissType.onTap like now, TopSnackBarDismissType.onSwipe or TopSnackBarDismissType.none)

I updated the example.

| DismissDirection.up | DismissDirection.endToStart |
| -------------------- | ---------------------------- |
| https://user-images.githubusercontent.com/22376981/176822421-631ccb37-5e63-4d55-9402-53547dca4f93.MP4 | https://user-images.githubusercontent.com/22376981/176822453-3fd4749c-bb79-4452-a27b-1e122f164460.MP4 |